### PR TITLE
Using crates.io directly as a source for nu plugins

### DIFF
--- a/examples/devenv/devenv.lock
+++ b/examples/devenv/devenv.lock
@@ -2,10 +2,10 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1727316705,
+        "lastModified": 1729273024,
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "5b03654ce046b5167e7b0bccbd8244cb56c16f0e",
+        "rev": "fa8b7445ddadc37850ed222718ca86622be01967",
         "type": "github"
       },
       "original": {
@@ -14,13 +14,28 @@
         "type": "github"
       }
     },
+    "crates-io-index": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1729618784,
+        "owner": "rust-lang",
+        "repo": "crates.io-index",
+        "rev": "1f0ac20b33d39c23cf79a2a4bfd3f02f3ac4d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "repo": "crates.io-index",
+        "type": "github"
+      }
+    },
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1727457166,
+        "lastModified": 1729604821,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "6090da46bfb53e358b818cee491df1a25daa85e0",
+        "rev": "52e7575398ec362c0963fed42dabb6fce8dc7cc4",
         "type": "github"
       },
       "original": {
@@ -42,23 +57,6 @@
       "original": {
         "owner": "edolstra",
         "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1726560853,
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -99,10 +97,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727492312,
+        "lastModified": 1729428082,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4471f9f67fe0f95f5fec4cc2ebac59fe32af2b62",
+        "rev": "ca30f584e18024baf39c395001262ed936f27ebd",
         "type": "github"
       },
       "original": {
@@ -114,10 +112,10 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1727397532,
+        "lastModified": 1729449015,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f65141456289e81ea0d5a05af8898333cab5c53d",
+        "rev": "89172919243df199fe237ba0f776c3e3e3d72367",
         "type": "github"
       },
       "original": {
@@ -129,10 +127,10 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1727492312,
+        "lastModified": 1729428082,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4471f9f67fe0f95f5fec4cc2ebac59fe32af2b62",
+        "rev": "ca30f584e18024baf39c395001262ed936f27ebd",
         "type": "github"
       },
       "original": {
@@ -157,15 +155,28 @@
         "type": "github"
       }
     },
+    "nu_plugin_httpserve-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1729603579,
+        "owner": "YPares",
+        "repo": "nu_plugin_httpserve",
+        "rev": "41963e81b74dc326b4b4fe22b2c9fb655aec89f0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "YPares",
+        "repo": "nu_plugin_httpserve",
+        "type": "github"
+      }
+    },
     "nushellWith": {
       "inputs": {
         "crane": "crane",
-        "flake-utils": "flake-utils",
+        "crates-io-index": "crates-io-index",
         "nixpkgs": "nixpkgs_2",
         "nu-batteries-src": "nu-batteries-src",
-        "plugin-explore-src": "plugin-explore-src",
-        "plugin-file-src": "plugin-file-src",
-        "plugin-plotters-src": "plugin-plotters-src",
+        "nu_plugin_httpserve-src": "nu_plugin_httpserve-src",
         "webserver-nu-src": "webserver-nu-src"
       },
       "locked": {
@@ -178,51 +189,6 @@
       },
       "parent": []
     },
-    "plugin-explore-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1726911003,
-        "owner": "amtoine",
-        "repo": "nu_plugin_explore",
-        "rev": "552ccb7c6a3f3780b07cc1d73afec3f99fbd4452",
-        "type": "github"
-      },
-      "original": {
-        "owner": "amtoine",
-        "repo": "nu_plugin_explore",
-        "type": "github"
-      }
-    },
-    "plugin-file-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1726668693,
-        "owner": "fdncred",
-        "repo": "nu_plugin_file",
-        "rev": "253417750662690baac3e818e15009edb1343d64",
-        "type": "github"
-      },
-      "original": {
-        "owner": "fdncred",
-        "repo": "nu_plugin_file",
-        "type": "github"
-      }
-    },
-    "plugin-plotters-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1727433053,
-        "owner": "cptpiepmatz",
-        "repo": "nu-jupyter-kernel",
-        "rev": "11c2540caab608f888e40d34d44aa7b570ca2518",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cptpiepmatz",
-        "repo": "nu-jupyter-kernel",
-        "type": "github"
-      }
-    },
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -233,10 +199,10 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727514110,
+        "lastModified": 1729104314,
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "85f7a7177c678de68224af3402ab8ee1bcee25c8",
+        "rev": "3c3e88f0f544d6bb54329832616af7eb971b6be6",
         "type": "github"
       },
       "original": {
@@ -254,27 +220,13 @@
         "pre-commit-hooks": "pre-commit-hooks"
       }
     },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "webserver-nu-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1725923972,
+        "lastModified": 1729079694,
         "owner": "Jan9103",
         "repo": "webserver.nu",
-        "rev": "9d7d43b19bbe85fdd7e951d5ff76f7a1f7fde34e",
+        "rev": "c94179bd28f9e70ec15a23cfdd52faa1763561bb",
         "type": "github"
       },
       "original": {

--- a/examples/devenv/devenv.nix
+++ b/examples/devenv/devenv.nix
@@ -6,7 +6,7 @@ let
   nupkgs = inputs.nushellWith.packages.${pkgs.system}; 
   myNushell = inputs.nushellWith {
     inherit pkgs;
-    plugins.nix = [ pkgs.nushellPlugins.polars ];
+    plugins.nix = [ nupkgs.nu_plugin_polars ];
     plugins.source = [ inputs.highlight ];
     libraries.source = [ nupkgs.nu-batteries ];
   };

--- a/examples/flake/flake.lock
+++ b/examples/flake/flake.lock
@@ -2,16 +2,32 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1728344376,
-        "narHash": "sha256-lxTce2XE6mfJH8Zk6yBbqsbu9/jpwdymbSH5cCbiVOA=",
+        "lastModified": 1729273024,
+        "narHash": "sha256-Mb5SemVsootkn4Q2IiY0rr9vrXdCCpQ9HnZeD/J3uXs=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "fd86b78f5f35f712c72147427b1eb81a9bd55d0b",
+        "rev": "fa8b7445ddadc37850ed222718ca86622be01967",
         "type": "github"
       },
       "original": {
         "owner": "ipetkov",
         "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crates-io-index": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1729616034,
+        "narHash": "sha256-g+JMLRuOkC30WU4ZuGUO4BxYwJeD64lqh/0OAfMGVhU=",
+        "owner": "rust-lang",
+        "repo": "crates.io-index",
+        "rev": "9507368b05c12f9f8f50d1485d8ef7e6a75e8b94",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "repo": "crates.io-index",
         "type": "github"
       }
     },
@@ -35,11 +51,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728249353,
-        "narHash": "sha256-7NBJm1jfMeAowE1J2oljYqWVvI9X7FyyxBY4O8uB/Os=",
+        "lastModified": 1729428082,
+        "narHash": "sha256-xb4/Y+Y7ZlkQaA5rXnrXplDzdt2Jfgdmar3+qkb56UA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c8a17040be4a20b29589cb4043a9e0c36af1930e",
+        "rev": "ca30f584e18024baf39c395001262ed936f27ebd",
         "type": "github"
       },
       "original": {
@@ -65,92 +81,42 @@
         "type": "github"
       }
     },
+    "nu_plugin_httpserve-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1729603579,
+        "narHash": "sha256-fbBIpT3xOX+WbuPH6B0+4aaB0GFWpzVxMMoWkvsD+jc=",
+        "owner": "YPares",
+        "repo": "nu_plugin_httpserve",
+        "rev": "41963e81b74dc326b4b4fe22b2c9fb655aec89f0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "YPares",
+        "repo": "nu_plugin_httpserve",
+        "type": "github"
+      }
+    },
     "nushellWith": {
       "inputs": {
         "crane": "crane",
+        "crates-io-index": "crates-io-index",
         "nixpkgs": [
           "nixpkgs"
         ],
         "nu-batteries-src": "nu-batteries-src",
-        "plugin-explore-src": "plugin-explore-src",
-        "plugin-file-src": "plugin-file-src",
-        "plugin-httpserve-src": "plugin-httpserve-src",
-        "plugin-plotters-src": "plugin-plotters-src",
+        "nu_plugin_httpserve-src": "nu_plugin_httpserve-src",
         "webserver-nu-src": "webserver-nu-src"
       },
       "locked": {
         "lastModified": 0,
-        "narHash": "sha256-96PeOCrEfQY2cqDk2xDJFKxdGAp2tjjOnTH6iElQRYU=",
-        "path": "/nix/store/5qn81s4c3ldqlrm97jfia8c5pqizad1s-source",
+        "narHash": "sha256-IZRN8q/1ZFEHo0fwxs67laAgpTabrdSaxriGnC1X/Js=",
+        "path": "/nix/store/6p1h8bap4axsx9zagnblcx1n3mb8x2yi-source",
         "type": "path"
       },
       "original": {
-        "path": "/nix/store/5qn81s4c3ldqlrm97jfia8c5pqizad1s-source",
+        "path": "/nix/store/6p1h8bap4axsx9zagnblcx1n3mb8x2yi-source",
         "type": "path"
-      }
-    },
-    "plugin-explore-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1726911003,
-        "narHash": "sha256-EX44IzxEJWK/kzLJ+edUUbGjZMbXJeM+p2/E4kGzrfM=",
-        "owner": "amtoine",
-        "repo": "nu_plugin_explore",
-        "rev": "552ccb7c6a3f3780b07cc1d73afec3f99fbd4452",
-        "type": "github"
-      },
-      "original": {
-        "owner": "amtoine",
-        "repo": "nu_plugin_explore",
-        "type": "github"
-      }
-    },
-    "plugin-file-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1726668693,
-        "narHash": "sha256-pOQ1t0aJiFunA69+EU6qVzUu25tGQzgzZiSISBwgdGA=",
-        "owner": "fdncred",
-        "repo": "nu_plugin_file",
-        "rev": "253417750662690baac3e818e15009edb1343d64",
-        "type": "github"
-      },
-      "original": {
-        "owner": "fdncred",
-        "repo": "nu_plugin_file",
-        "type": "github"
-      }
-    },
-    "plugin-httpserve-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1728309768,
-        "narHash": "sha256-c9eyleux+dcQCK2yTTpmDF/SedMc5oirZFLpsw5FC6Q=",
-        "owner": "YPares",
-        "repo": "nu_plugin_httpserve",
-        "rev": "63ac92e7b95c862949b1440965dd3e2810b25bd7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "YPares",
-        "repo": "nu_plugin_httpserve",
-        "type": "github"
-      }
-    },
-    "plugin-plotters-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1727433053,
-        "narHash": "sha256-ZaB1ZCOa7cM2a9vX9vXa+SjvPikx6tNVR1IpBxuhZec=",
-        "owner": "cptpiepmatz",
-        "repo": "nu-jupyter-kernel",
-        "rev": "11c2540caab608f888e40d34d44aa7b570ca2518",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cptpiepmatz",
-        "repo": "nu-jupyter-kernel",
-        "type": "github"
       }
     },
     "root": {
@@ -178,11 +144,11 @@
     "webserver-nu-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1725923972,
-        "narHash": "sha256-JVE3osZQvbT+ufjulKsgf3OGj93LD7LjbreS21TTTOk=",
+        "lastModified": 1729079694,
+        "narHash": "sha256-fliqQpg7bIN26MgMR7EPiWI5NL/BNkuvNTloIXTo178=",
         "owner": "Jan9103",
         "repo": "webserver.nu",
-        "rev": "9d7d43b19bbe85fdd7e951d5ff76f7a1f7fde34e",
+        "rev": "c94179bd28f9e70ec15a23cfdd52faa1763561bb",
         "type": "github"
       },
       "original": {

--- a/examples/flake/flake.nix
+++ b/examples/flake/flake.nix
@@ -20,7 +20,7 @@
         nupkgs = nushellWith.packages.${system};
         myNushell = nushellWith {
           inherit pkgs;
-          plugins.nix = [ nupkgs.plugin-httpserve ];
+          plugins.nix = [ nupkgs.nu_plugin_httpserve ];
           libraries.source = [ nupkgs.nu-batteries ];
           env-vars-file = ./env-vars;
         };

--- a/flake.lock
+++ b/flake.lock
@@ -15,6 +15,22 @@
         "type": "github"
       }
     },
+    "crates-io-index": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1729616034,
+        "narHash": "sha256-g+JMLRuOkC30WU4ZuGUO4BxYwJeD64lqh/0OAfMGVhU=",
+        "owner": "rust-lang",
+        "repo": "crates.io-index",
+        "rev": "9507368b05c12f9f8f50d1485d8ef7e6a75e8b94",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "repo": "crates.io-index",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1729428082,
@@ -44,38 +60,6 @@
       "original": {
         "owner": "nome",
         "repo": "nu-batteries",
-        "type": "github"
-      }
-    },
-    "plugin-explore-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1726911003,
-        "narHash": "sha256-EX44IzxEJWK/kzLJ+edUUbGjZMbXJeM+p2/E4kGzrfM=",
-        "owner": "amtoine",
-        "repo": "nu_plugin_explore",
-        "rev": "552ccb7c6a3f3780b07cc1d73afec3f99fbd4452",
-        "type": "github"
-      },
-      "original": {
-        "owner": "amtoine",
-        "repo": "nu_plugin_explore",
-        "type": "github"
-      }
-    },
-    "plugin-file-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1729542312,
-        "narHash": "sha256-2dSdNC89D1IJgbUq+S5FN8ue5BJNOs8exzlYB0Jqj1w=",
-        "owner": "fdncred",
-        "repo": "nu_plugin_file",
-        "rev": "839fadec3b9b6b52475ffea7be39427ae49142ad",
-        "type": "github"
-      },
-      "original": {
-        "owner": "fdncred",
-        "repo": "nu_plugin_file",
         "type": "github"
       }
     },
@@ -111,32 +95,14 @@
         "type": "github"
       }
     },
-    "plugin-vec-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1729451494,
-        "narHash": "sha256-cFT413IhDxP7PZE6j+wfFqwlsRvi7Y9M8pi9wB+msi8=",
-        "owner": "PhotonBursted",
-        "repo": "nu_plugin_vec",
-        "rev": "4c4c6707b990274a72cbf2412b7fdc358a93d4c2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "PhotonBursted",
-        "repo": "nu_plugin_vec",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "crane": "crane",
+        "crates-io-index": "crates-io-index",
         "nixpkgs": "nixpkgs",
         "nu-batteries-src": "nu-batteries-src",
-        "plugin-explore-src": "plugin-explore-src",
-        "plugin-file-src": "plugin-file-src",
         "plugin-httpserve-src": "plugin-httpserve-src",
         "plugin-plotters-src": "plugin-plotters-src",
-        "plugin-vec-src": "plugin-vec-src",
         "webserver-nu-src": "webserver-nu-src"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     "crates-io-index": {
       "flake": false,
       "locked": {
-        "lastModified": 1729616034,
-        "narHash": "sha256-g+JMLRuOkC30WU4ZuGUO4BxYwJeD64lqh/0OAfMGVhU=",
+        "lastModified": 1729618988,
+        "narHash": "sha256-H3X7XPLT2AaFQKev8g8tot3FOQrannHLGbea/9i6RB8=",
         "owner": "rust-lang",
         "repo": "crates.io-index",
-        "rev": "9507368b05c12f9f8f50d1485d8ef7e6a75e8b94",
+        "rev": "4771254cadd563971d1f8282da97a5fa923387aa",
         "type": "github"
       },
       "original": {
@@ -63,7 +63,7 @@
         "type": "github"
       }
     },
-    "plugin-httpserve-src": {
+    "nu_plugin_httpserve-src": {
       "flake": false,
       "locked": {
         "lastModified": 1729603579,
@@ -79,30 +79,13 @@
         "type": "github"
       }
     },
-    "plugin-plotters-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1729200536,
-        "narHash": "sha256-A1Y3SwmjQ6Mp5LrLTMoOaaP+V5eKxbQC0YLANuGufGs=",
-        "owner": "cptpiepmatz",
-        "repo": "nu-jupyter-kernel",
-        "rev": "3c29023ed8ed2c110cf4656175ac9d3acd1e5529",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cptpiepmatz",
-        "repo": "nu-jupyter-kernel",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "crane": "crane",
         "crates-io-index": "crates-io-index",
         "nixpkgs": "nixpkgs",
         "nu-batteries-src": "nu-batteries-src",
-        "plugin-httpserve-src": "plugin-httpserve-src",
-        "plugin-plotters-src": "plugin-plotters-src",
+        "nu_plugin_httpserve-src": "nu_plugin_httpserve-src",
         "webserver-nu-src": "webserver-nu-src"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
     crane.url = "github:ipetkov/crane";
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-    # Nu libraries sources:
+    # Nu libraries' sources:
     nu-batteries-src = {
       url = "github:nome/nu-batteries";
       flake = false;
@@ -22,15 +22,7 @@
       flake = false;
     };
 
-    # Nu plugins sources:
-    plugin-explore-src = {
-      url = "github:amtoine/nu_plugin_explore";
-      flake = false;
-    };
-    plugin-file-src = {
-      url = "github:fdncred/nu_plugin_file";
-      flake = false;
-    };
+    # Nu plugins' sources:
     plugin-httpserve-src = {
       url = "github:YPares/nu_plugin_httpserve";
       flake = false;
@@ -39,8 +31,9 @@
       url = "github:cptpiepmatz/nu-jupyter-kernel";
       flake = false;
     };
-    plugin-vec-src = {
-      url = "github:PhotonBursted/nu_plugin_vec";
+
+    crates-io-index = {
+      url = "github:rust-lang/crates.io-index";
       flake = false;
     };
   };
@@ -71,9 +64,7 @@
           inputs-for-libs = {
             inherit pkgs;
             inherit system;
-            inherit (self.lib) makeNuLibrary;
           } // (builtins.removeAttrs flake-inputs [
-            "self"
             "nixpkgs"
             "flake-utils"
           ]);

--- a/flake.nix
+++ b/flake.nix
@@ -23,12 +23,8 @@
     };
 
     # Nu plugins' sources:
-    plugin-httpserve-src = {
+    nu_plugin_httpserve-src = {
       url = "github:YPares/nu_plugin_httpserve";
-      flake = false;
-    };
-    plugin-plotters-src = {
-      url = "github:cptpiepmatz/nu-jupyter-kernel";
       flake = false;
     };
 

--- a/nix-src/nu-libs-and-plugins.nix
+++ b/nix-src/nu-libs-and-plugins.nix
@@ -55,8 +55,8 @@ in pluginsFromCratesIo // {
 
   # Plugins (rust code) from github 
 
-  plugin-httpserve = craneLib.buildPackage {
-    src = craneLib.cleanCargoSource inputs.plugin-httpserve-src;
+  nu_plugin_httpserve = craneLib.buildPackage {
+    src = craneLib.cleanCargoSource inputs.nu_plugin_httpserve-src;
     buildInputs = baseBuildInputs;
   };
 

--- a/nu-src/list-plugins-in-index.nu
+++ b/nu-src/list-plugins-in-index.nu
@@ -1,0 +1,20 @@
+def parse-one [path] {
+    open -r $path |
+    from json --objects |
+    last | # Select the most recent version
+    select name vers cksum |
+    rename name version checksum
+}
+
+def to-attr-name [] {
+    str replace "nu_plugin_" "plugin-"
+}
+
+def main [crates_io_index] {
+    mkdir $env.out
+    ls $"($crates_io_index)/nu/_p" |
+        where {($in.name | path parse).stem | str starts-with "nu_plugin_"} |
+        each {parse-one $in.name | {($in.name | to-attr-name): $in}} |
+        into record |
+        save $"($env.out)/plugins.json"
+}

--- a/nu-src/list-plugins-in-index.nu
+++ b/nu-src/list-plugins-in-index.nu
@@ -6,15 +6,11 @@ def parse-one [path] {
     rename name version checksum
 }
 
-def to-attr-name [] {
-    str replace "nu_plugin_" "plugin-"
-}
-
 def main [crates_io_index] {
     mkdir $env.out
     ls $"($crates_io_index)/nu/_p" |
         where {($in.name | path parse).stem | str starts-with "nu_plugin_"} |
-        each {parse-one $in.name | {($in.name | to-attr-name): $in}} |
+        each {parse-one $in.name | {$in.name: $in}} |
         into record |
         save $"($env.out)/plugins.json"
 }


### PR DESCRIPTION
This MR packages every nu_plugin_* crate available on crates.io.

Of course, not all of them can build directly, some need extra system dependencies that must be added to that flake on a case-by-case fashion.